### PR TITLE
Reduce startup delays due to `healthcheck`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,8 @@ services:
     restart: unless-stopped
     healthcheck:
       test: [CMD, nfdc, status]
-      interval: 30s
+      interval: 1m
+      start_period: 30s
     depends_on:
       master: { condition: service_healthy }
     logging:
@@ -130,7 +131,7 @@ services:
     restart: unless-stopped
     healthcheck:
       test: echo 'db.runCommand("ping").ok' | ${MONGO_SH:-mongosh} --quiet
-      interval: 5s
+      start_period: 30s
     logging:
       driver: local
 


### PR DESCRIPTION
Use a 30s `start_period` for nfd and mongodb. During the start period, health checks are run every 5s (the default `start_interval`) which provides faster reaction to restarts.

With this improved mechanism, we can also increase the regular health check interval for nfd to 1 minute to further reduce the overhead.

Please note that this is completely untested.