### PR TITLE
Expose MongoDB Port Locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,8 @@ services:
       interval: 5s
     logging:
       driver: local
+    ports:
+      - 27017:27017
 
   ndn-python-repo:
     image: ghcr.io/ucla-irl/ndn-python-repo:20240508


### PR DESCRIPTION
for debugging purposes, we expose the MongoDB port to the local machine