### PR TITLE
Feature/trace-collector-service

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -51,6 +51,9 @@ services:
     template_path: templates/file-server
     render_path: dist/file-server
 
+  trace-collector:
+    pass: on
+
 # Global variables that are available in all templates
 globals:
   ndnNetwork: /ndn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,3 +220,17 @@ services:
       nfd: { condition: service_healthy }
     logging:
       driver: local
+
+  trace-collector:
+    image: sankalpatimilsina/scheduler:latest
+    init: true
+    network_mode: service:nfd
+    volumes:
+      - /home/.ssh:/root/.ssh:ro
+      - /home/ndnops/ndntdump-exp-2023:/dump
+      - ${PWD}/dist/nlsr:/config
+    restart: unless-stopped
+    depends_on:
+      nfd: { condition: service_healthy }
+    logging:
+      driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,12 +222,12 @@ services:
       driver: local
 
   trace-collector:
-    image: sankalpatimilsina/scheduler:latest
+    image: ghcr.io/sankalpatimilsina12/trace-collector:20250214
     init: true
     network_mode: service:nfd
     volumes:
       - /home/.ssh:/root/.ssh:ro
-      - /home/ndnops/ndntdump-exp-2023:/dump
+      - /home/ndnops/traces:/dump
       - ${PWD}/dist/nlsr:/config
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
This adds a dockerized trace collection service.

1. The directory has been renamed from the original `ndntdump-exp-2023` to generic `traces` which will be present on the host and will contain collected traces.
2. The image is under GCR, tagged and is under a username, happy to upload elsewhere.