### PR TITLE
Naming convention changes

### DIFF
--- a/host_vars/AFA
+++ b/host_vars/AFA
@@ -1,4 +1,4 @@
-site: /it/afasystems
+site: /afa.testbed.named-data.net
 site_name: AFA Systems, Italy
 operator_name: Gianmichele Russi
 operator_email: russi@afasystems.it
@@ -7,13 +7,13 @@ host_ip: 213.203.158.40
 local_ip: 213.203.158.40
 site_email_domain:
 - afasystems.it
-default_prefix: /ndn/it/afasystems
+default_prefix: /ndn/afa.testbed.named-data.net
 advertised_prefixes:
-- /ndn/it/afasystems
+- /ndn/afa.testbed.named-data.net
 routable_prefixes:
-- /ndn/it/afasystems
+- /ndn/afa.testbed.named-data.net
 network_regions:
-- /ndn/it/afasystems
+- /ndn/afa.testbed.named-data.net
 router_name: ndn
 http_access: https
 memsize: 4

--- a/host_vars/ANYANG
+++ b/host_vars/ANYANG
@@ -1,4 +1,4 @@
-site: /kr/anyang
+site: /anyang.testbed.named-data.net
 site_name: Anyang University, South Korea
 operator_name: Euihyun Jung
 operator_email: jung@anyang.ac.kr
@@ -7,13 +7,13 @@ host_ip: 210.114.89.49
 local_ip: 210.114.89.49
 site_email_domain:
 - anyang.ac.kr
-default_prefix: /ndn/kr/anyang
+default_prefix: /ndn/anyang.testbed.named-data.net
 advertised_prefixes:
-- /ndn/kr/anyang
+- /ndn/anyang.testbed.named-data.net
 routable_prefixes:
-- /ndn/kr/anyang
+- /ndn/anyang.testbed.named-data.net
 network_regions:
-- /ndn/kr/anyang
+- /ndn/anyang.testbed.named-data.net
 router_name: anyanghub
 http_access: http
 memsize: 48

--- a/host_vars/ARIZONA
+++ b/host_vars/ARIZONA
@@ -1,4 +1,4 @@
-site: /edu/arizona
+site: /hobo.cs.arizona.edu
 site_name: The University of Arizona
 operator_name: Teng Liang
 operator_email: philoliang2011@gmail.com
@@ -9,14 +9,14 @@ site_email_domain:
 - arizona.edu
 - cs.arizona.edu
 - email.arizona.edu
-default_prefix: /ndn/edu/arizona
+default_prefix: /ndn/hobo.cs.arizona.edu
 advertised_prefixes:
-- /ndn/edu/arizona
+- /ndn/hobo.cs.arizona.edu
 - /ndn/web/stats
 routable_prefixes:
-- /ndn/edu/arizona
+- /ndn/hobo.cs.arizona.edu
 network_regions:
-- /ndn/edu/arizona
+- /ndn/hobo.cs.arizona.edu
 router_name: hobo
 http_access: https
 memsize: 8

--- a/host_vars/AVEIRO
+++ b/host_vars/AVEIRO
@@ -1,4 +1,4 @@
-site: /pt/it/av
+site: /selficn.av.it.pt
 site_name: University of Aveiro, Portugal
 operator_name: Jose Quevedo
 operator_email: quevedo@av.it.pt
@@ -9,13 +9,13 @@ outgoing_subnets:
 - 193.136.80.0/20
 site_email_domain:
 - av.it.pt
-default_prefix: /ndn/pt/it/av
+default_prefix: /ndn/selficn.av.it.pt
 advertised_prefixes:
-- /ndn/pt/it/av
+- /ndn/selficn.av.it.pt
 routable_prefixes:
-- /ndn/pt/it/av
+- /ndn/selficn.av.it.pt
 network_regions:
-- /ndn/pt/it/av
+- /ndn/selficn.av.it.pt
 router_name: selficn
 http_access: https
 memsize: 4

--- a/host_vars/BERN
+++ b/host_vars/BERN
@@ -1,4 +1,4 @@
-site: /ch/unibe
+site: /os-float159.cnds.unibe.ch
 site_name: University of Bern, Switzerland
 operator_name: Jonnahtan Saltarin
 operator_email: saltarin@inf.unibe.ch
@@ -7,13 +7,13 @@ host_ip: 130.92.70.159
 local_ip: 192.168.111.10
 site_email_domain:
 - inf.unibe.ch
-default_prefix: /ndn/ch/unibe
+default_prefix: /ndn/os-float159.cnds.unibe.ch
 advertised_prefixes:
-- /ndn/ch/unibe
+- /ndn/os-float159.cnds.unibe.ch
 routable_prefixes:
-- /ndn/ch/unibe
+- /ndn/os-float159.cnds.unibe.ch
 network_regions:
-- /ndn/ch/unibe
+- /ndn/os-float159.cnds.unibe.ch
 router_name: ndn-1
 http_access: http
 memsize: 2

--- a/host_vars/DELFT
+++ b/host_vars/DELFT
@@ -1,4 +1,4 @@
-site: /nl/delft
+site: /ndn-testbed.ewi.tudelft.nl
 site_name: Delft University of Technology, Netherlands
 operator_name: Chhagan Lal
 operator_email: c.lal@tudelft.nl
@@ -7,13 +7,13 @@ host_ip: 131.180.178.63
 local_ip: 131.180.178.63
 site_email_domain:
 - delft.nl
-default_prefix: /ndn/nl/delft
+default_prefix: /ndn/ndn-testbed.ewi.tudelft.nl
 advertised_prefixes:
-- /ndn/nl/delft
+- /ndn/ndn-testbed.ewi.tudelft.nl
 routable_prefixes:
-- /ndn/nl/delft
+- /ndn/ndn-testbed.ewi.tudelft.nl
 network_regions:
-- /ndn/nl/delft
+- /ndn/ndn-testbed.ewi.tudelft.nl
 router_name: ndn-testbed
 http_access: https
 memsize: 4

--- a/host_vars/FRANKFURT
+++ b/host_vars/FRANKFURT
@@ -1,4 +1,4 @@
-site: /pcl/frankfurt
+site: /frankfurt.testbed.named-data.net
 site_name: PCL Frankfurt
 operator_name: Teng Liang
 operator_email: redact@pcl.ac.cn
@@ -6,13 +6,13 @@ ansible_host: frankfurt.testbed.named-data.net
 host_ip: 49.51.163.56
 local_ip: 49.51.163.56
 site_email_domain: []
-default_prefix: /ndn/pcl/frankfurt
+default_prefix: /ndn/frankfurt.testbed.named-data.net
 advertised_prefixes:
-- /ndn/pcl/frankfurt
+- /ndn/frankfurt.testbed.named-data.net
 routable_prefixes:
-- /ndn/pcl/frankfurt
+- /ndn/frankfurt.testbed.named-data.net
 network_regions:
-- /ndn/pcl/frankfurt
+- /ndn/frankfurt.testbed.named-data.net
 router_name: vm
 http_access: https
 memsize: 8

--- a/host_vars/IIITH
+++ b/host_vars/IIITH
@@ -1,4 +1,4 @@
-site: /in/ac/iiith
+site: /ndntestbed.iiit.ac.in
 site_name: International Institute of Information Technology, Hyderabad, India
 operator_name: Madhubabu Dontineni
 operator_email: madhu@iiit.ac.in
@@ -7,13 +7,13 @@ host_ip: 14.139.82.16
 local_ip: 14.139.82.16
 site_email_domain:
 - iiit.ac.in
-default_prefix: /ndn/in/ac/iiith
+default_prefix: /ndn/ndntestbed.iiit.ac.in
 advertised_prefixes:
-- /ndn/in/ac/iiith
+- /ndn/ndntestbed.iiit.ac.in
 routable_prefixes:
-- /ndn/in/ac/iiith
+- /ndn/ndntestbed.iiit.ac.in
 network_regions:
-- /ndn/in/ac/iiith
+- /ndn/ndntestbed.iiit.ac.in
 router_name: ndntestbed
 http_access: http
 memsize: 2

--- a/host_vars/MEMPHIS
+++ b/host_vars/MEMPHIS
@@ -1,4 +1,4 @@
-site: /edu/memphis
+site: /titan.cs.memphis.edu
 site_name: The University of Memphis
 operator_name: Saurab Dulal
 operator_email: sdulal@memphis.edu
@@ -7,13 +7,13 @@ host_ip: 141.225.11.173
 local_ip: 141.225.11.173
 site_email_domain:
 - memphis.edu
-default_prefix: /ndn/edu/memphis
+default_prefix: /ndn/titan.cs.memphis.edu
 advertised_prefixes:
-- /ndn/edu/memphis
+- /ndn/titan.cs.memphis.edu
 routable_prefixes:
-- /ndn/edu/memphis
+- /ndn/titan.cs.memphis.edu
 network_regions:
-- /ndn/edu/memphis
+- /ndn/titan.cs.memphis.edu
 router_name: titan
 http_access: https
 memsize: 4

--- a/host_vars/MINHO
+++ b/host_vars/MINHO
@@ -1,4 +1,4 @@
-site: /pt/uminho
+site: /vnetlab.gcom.di.uminho.pt
 site_name: University of Minho, Portugal
 operator_name: Ertugrul Dogruluk
 operator_email: id5540@alunos.uminho.pt
@@ -8,13 +8,13 @@ local_ip: 193.136.9.206
 site_email_domain:
 - di.minho.pt
 - alunos.uminho.pt
-default_prefix: /ndn/pt/uminho
+default_prefix: /ndn/vnetlab.gcom.di.uminho.pt
 advertised_prefixes:
-- /ndn/pt/uminho
+- /ndn/vnetlab.gcom.di.uminho.pt
 routable_prefixes:
-- /ndn/pt/uminho
+- /ndn/vnetlab.gcom.di.uminho.pt
 network_regions:
-- /ndn/pt/uminho
+- /ndn/vnetlab.gcom.di.uminho.pt
 router_name: vnetlab
 http_access: https
 memsize: 4

--- a/host_vars/MML1
+++ b/host_vars/MML1
@@ -1,4 +1,4 @@
-site: /gr/edu/mmlab1
+site: /mmlab-aueb-1.mmlab.edu.gr
 site_name: Athens University of Economics and Business, Greece
 operator_name: Nikos Fotiou
 operator_email: fotiou@aueb.gr
@@ -7,14 +7,14 @@ host_ip: 195.251.234.11
 local_ip: 195.251.234.11
 site_email_domain:
 - aueb.gr
-default_prefix: /ndn/gr/edu/mmlab1
+default_prefix: /ndn/mmlab-aueb-1.mmlab.edu.gr
 advertised_prefixes:
-- /ndn/gr/edu/mmlab1
-- /ndn/gr/aueb
+- /ndn/mmlab-aueb-1.mmlab.edu.gr
+- /ndn/mmlab-aueb-1.mmlab.edu.gr/aueb
 routable_prefixes:
-- /ndn/gr/edu/mmlab1
+- /ndn/mmlab-aueb-1.mmlab.edu.gr
 network_regions:
-- /ndn/gr/edu/mmlab1
+- /ndn/mmlab-aueb-1.mmlab.edu.gr
 router_name: mmlab1
 http_access: http
 memsize: 2

--- a/host_vars/MML2
+++ b/host_vars/MML2
@@ -1,4 +1,4 @@
-site: /gr/edu/mmlab2
+site: /mmlab-aueb-2.mmlab.edu.gr
 site_name: Athens University of Economics and Business, Greece
 operator_name: Nikos Fotiou
 operator_email: fotiou@aueb.gr
@@ -7,13 +7,13 @@ host_ip: 195.251.234.12
 local_ip: 195.251.234.12
 site_email_domain:
 - aueb.gr
-default_prefix: /ndn/gr/edu/mmlab2
+default_prefix: /ndn/mmlab-aueb-2.mmlab.edu.gr
 advertised_prefixes:
-- /ndn/gr/edu/mmlab2
+- /ndn/mmlab-aueb-2.mmlab.edu.gr
 routable_prefixes:
-- /ndn/gr/edu/mmlab2
+- /ndn/mmlab-aueb-2.mmlab.edu.gr
 network_regions:
-- /ndn/gr/edu/mmlab1
+- /ndn/mmlab-aueb-2.mmlab.edu.gr
 router_name: mmlab12
 http_access: http
 memsize: 2

--- a/host_vars/NEU
+++ b/host_vars/NEU
@@ -1,4 +1,4 @@
-site: /edu/neu
+site: /neu.testbed.named-data.net
 site_name: Northeastern University
 operator_name: Ran Liu
 operator_email: liuranapply@gmail.com
@@ -7,13 +7,13 @@ host_ip: 155.33.178.42
 local_ip: 155.33.178.42
 site_email_domain:
 - neu.edu
-default_prefix: /ndn/edu/neu
+default_prefix: /ndn/neu.testbed.named-data.net
 advertised_prefixes:
-- /ndn/edu/neu
+- /ndn/neu.testbed.named-data.net
 routable_prefixes:
-- /ndn/edu/neu
+- /ndn/neu.testbed.named-data.net
 network_regions:
-- /ndn/edu/neu
+- /ndn/neu.testbed.named-data.net
 router_name: ndnrtr
 http_access: http
 memsize: 2

--- a/host_vars/OSAKA
+++ b/host_vars/OSAKA
@@ -1,4 +1,4 @@
-site: /jp/ac/osaka-u
+site: /ndn.ist.osaka-u.ac.jp
 site_name: Osaka University, Japan
 operator_name: Yuki Koizumi
 operator_email: ykoizumi@ist.osaka-u.ac.jp
@@ -7,13 +7,13 @@ host_ip: 133.1.17.51
 local_ip: 133.1.17.51
 site_email_domain:
 - ist.osaka-u.ac.jp
-default_prefix: /ndn/jp/ac/osaka-u
+default_prefix: /ndn/ndn.ist.osaka-u.ac.jp
 advertised_prefixes:
-- /ndn/jp/ac/osaka-u
+- /ndn/ndn.ist.osaka-u.ac.jp
 routable_prefixes:
-- /ndn/jp/ac/osaka-u
+- /ndn/ndn.ist.osaka-u.ac.jp
 network_regions:
-- /ndn/jp/ac/osaka-u
+- /ndn/ndn.ist.osaka-u.ac.jp
 router_name: NDNtestbed
 http_access: http
 memsize: 16

--- a/host_vars/QUB
+++ b/host_vars/QUB
@@ -1,4 +1,4 @@
-site: /uk/ac/qub
+site: /ndn.qub.ac.uk
 site_name: Queen's University Belfast, UK
 operator_name: Paul McAllister
 operator_email: P.McAllister@qub.ac.uk
@@ -7,13 +7,13 @@ host_ip: 51.148.47.242
 local_ip: 10.60.60.2
 site_email_domain:
 - qub.ac.uk
-default_prefix: /ndn/uk/ac/qub
+default_prefix: /ndn/ndn.qub.ac.uk
 advertised_prefixes:
-- /ndn/uk/ac/qub
+- /ndn/ndn.qub.ac.uk
 routable_prefixes:
-- /ndn/uk/ac/qub
+- /ndn/ndn.qub.ac.uk
 network_regions:
-- /ndn/uk/ac/qub
+- /ndn/ndn.qub.ac.uk
 router_name: ndn
 http_access: https
 memsize: 8

--- a/host_vars/SAVI
+++ b/host_vars/SAVI
@@ -1,4 +1,4 @@
-site: /ca/utoronto
+site: /savi.testbed.named-data.net
 site_name: University of Toronto
 operator_name: Morteza Moghaddassian
 operator_email: m.moghaddassian@mail.utoronto.ca
@@ -8,13 +8,13 @@ local_ip: 10.30.44.13
 site_email_domain:
 - utoronto.ca
 - mail.utoronto.ca
-default_prefix: /ndn/ca/utoronto
+default_prefix: /ndn/savi.testbed.named-data.net
 advertised_prefixes:
-- /ndn/ca/utoronto
+- /ndn/savi.testbed.named-data.net
 routable_prefixes:
-- /ndn/ca/utoronto
+- /ndn/savi.testbed.named-data.net
 network_regions:
-- /ndn/ca/utoronto
+- /ndn/savi.testbed.named-data.net
 router_name: ndnrtr
 http_access: https
 memsize: 8

--- a/host_vars/SINGAPORE
+++ b/host_vars/SINGAPORE
@@ -1,4 +1,4 @@
-site: /pcl/singapore
+site: /singapore.testbed.named-data.net
 site_name: PCL Singapore
 operator_name: Teng Liang
 operator_email: redact@pcl.ac.cn
@@ -6,13 +6,13 @@ ansible_host: singapore.testbed.named-data.net
 host_ip: 43.134.56.106
 local_ip: 43.134.56.106
 site_email_domain: []
-default_prefix: /ndn/pcl/singapore
+default_prefix: /ndn/singapore.testbed.named-data.net
 advertised_prefixes:
-- /ndn/pcl/singapore
+- /ndn/singapore.testbed.named-data.net
 routable_prefixes:
-- /ndn/pcl/singapore
+- /ndn/singapore.testbed.named-data.net
 network_regions:
-- /ndn/pcl/singapore
+- /ndn/singapore.testbed.named-data.net
 router_name: vm
 http_access: https
 memsize: 8

--- a/host_vars/SRRU
+++ b/host_vars/SRRU
@@ -1,4 +1,4 @@
-site: /th/ac/srru
+site: /srru.testbed.named-data.net
 site_name: Surindra Rajabhat University, Thailand
 operator_name: 'Thongchai Chuachan '
 operator_email: thongchai.c@srru.ac.th
@@ -7,13 +7,13 @@ host_ip: 202.29.30.31
 local_ip: 192.168.2.60
 site_email_domain:
 - srru.ac.th
-default_prefix: /ndn/th/ac/srru
+default_prefix: /ndn/srru.testbed.named-data.net
 advertised_prefixes:
-- /ndn/th/ac/srru
+- /ndn/srru.testbed.named-data.net
 routable_prefixes:
-- /ndn/th/ac/srru
+- /ndn/srru.testbed.named-data.net
 network_regions:
-- /ndn/th/ac/srru
+- /ndn/srru.testbed.named-data.net
 router_name: comsci2
 http_access: https
 memsize: 8

--- a/host_vars/TNO
+++ b/host_vars/TNO
@@ -1,4 +1,4 @@
-site: /nl/tno
+site: /tno.testbed.named-data.net
 site_name: Netherlands Organisation for Applied Scientific Research, Netherlands
 operator_name: Bastiaan Wissingh
 operator_email: bastiaan.wissingh@tno.nl
@@ -7,13 +7,13 @@ host_ip: 134.221.116.42
 local_ip: 134.221.116.42
 site_email_domain:
 - tno.nl
-default_prefix: /ndn/nl/tno
+default_prefix: /ndn/tno.testbed.named-data.net
 advertised_prefixes:
-- /ndn/nl/tno
+- /ndn/tno.testbed.named-data.net
 routable_prefixes:
-- /ndn/nl/tno
+- /ndn/tno.testbed.named-data.net
 network_regions:
-- /ndn/nl/tno
+- /ndn/tno.testbed.named-data.net
 router_name: tno-ndntestbed-bordernode
 http_access: http
 memsize: 4

--- a/host_vars/UCLA
+++ b/host_vars/UCLA
@@ -1,4 +1,4 @@
-site: /edu/ucla
+site: /suns.cs.ucla.edu
 site_name: University of California, Los Angeles
 operator_name: Tianyuan Yu
 operator_email: royu29@g.ucla.edu
@@ -12,14 +12,14 @@ site_email_domain:
 - engineering.ucla.edu
 default_prefix: /ndn/edu/ucla
 advertised_prefixes:
-- /ndn/edu/ucla
+- /ndn/suns.cs.ucla.edu
 - /ndn/CA
 - /ndn/irl-workspace/20240525/CA
 - /ndn/weekly-call-doc/CA
 routable_prefixes:
-- /ndn/edu/ucla
+- /ndn/suns.cs.ucla.edu
 network_regions:
-- /ndn/edu/ucla
+- /ndn/suns.cs.ucla.edu
 router_name: suns
 http_access: https
 memsize: 10

--- a/host_vars/UFBA
+++ b/host_vars/UFBA
@@ -1,4 +1,4 @@
-site: /br/ufba
+site: /ufba.testbed.named-data.net
 site_name: Federal University of Bahia, Brazil
 operator_name: 'Thiago Bomfim '
 operator_email: thiagobomfim@pop-ba.rnp.br
@@ -7,13 +7,13 @@ host_ip: 200.128.51.61
 local_ip: 200.128.51.61
 site_email_domain:
 - pop-ba.rnp.br
-default_prefix: /ndn/br/ufba
+default_prefix: /ndn/ufba.testbed.named-data.net
 advertised_prefixes:
-- /ndn/br/ufba
+- /ndn/ufba.testbed.named-data.net
 routable_prefixes:
-- /ndn/br/ufba
+- /ndn/ufba.testbed.named-data.net
 network_regions:
-- /ndn/br/ufba
+- /ndn/ufba.testbed.named-data.net
 router_name: ndn-testbed-ufba
 http_access: https
 memsize: 2

--- a/host_vars/URJC
+++ b/host_vars/URJC
@@ -1,4 +1,4 @@
-site: /es/urjc
+site: /insula.gsyc.es
 site_name: Universidad Rey Juan Carlos, Spain
 operator_name: Pedro de las Heras Quiros
 operator_email: pheras@gsyc.es
@@ -8,13 +8,13 @@ local_ip: 193.147.79.41
 site_email_domain:
 - urjc.es
 - alumnos.urjc.es
-default_prefix: /ndn/es/urjc
+default_prefix: /ndn/insula.gsyc.es
 advertised_prefixes:
-- /ndn/es/urjc
+- /ndn/insula.gsyc.es
 routable_prefixes:
-- /ndn/es/urjc
+- /ndn/insula.gsyc.es
 network_regions:
-- /ndn/es/urjc
+- /ndn/insula.gsyc.es
 router_name: insula
 http_access: https
 memsize: 24

--- a/host_vars/WASEDA
+++ b/host_vars/WASEDA
@@ -1,4 +1,4 @@
-site: /jp/waseda
+site: /ndn-tb.nz.comm.waseda.ac.jp
 site_name: Waseda University, Tokyo, Japan
 operator_name: Xiabo Li
 operator_email: lxb385@fuji.waseda.jp
@@ -8,13 +8,13 @@ local_ip: 133.9.67.98
 site_email_domain:
 - waseda.jp
 - fuji.waseda.jp
-default_prefix: /ndn/jp/waseda
+default_prefix: /ndn/ndn-tb.nz.comm.waseda.ac.jp
 advertised_prefixes:
-- /ndn/jp/waseda
+- /ndn/ndn-tb.nz.comm.waseda.ac.jp
 routable_prefixes:
-- /ndn/jp/waseda
+- /ndn/ndn-tb.nz.comm.waseda.ac.jp
 network_regions:
-- /ndn/jp/waseda
+- /ndn/ndn-tb.nz.comm.waseda.ac.jp
 router_name: ndn-tb
 http_access: htt
 memsize: 2

--- a/host_vars/WU
+++ b/host_vars/WU
@@ -1,4 +1,4 @@
-site: /edu/wustl
+site: /wundngw.wustl.edu
 site_name: Washington University in St. Louis
 operator_name: John DeHart
 operator_email: jdd@wustl.edu
@@ -7,13 +7,13 @@ host_ip: 128.252.185.35
 local_ip: 128.252.185.35
 site_email_domain:
 - wustl.edu
-default_prefix: /ndn/edu/wustl
+default_prefix: /ndn/wundngw.wustl.edu
 advertised_prefixes:
-- /ndn/edu/wustl
+- /ndn/wundngw.wustl.edu
 routable_prefixes:
-- /ndn/edu/wustl
+- /ndn/wundngw.wustl.edu
 network_regions:
-- /ndn/edu/wustl
+- /ndn/wundngw.wustl.edu
 router_name: wundngw
 http_access: https
 memsize: 2

--- a/templates/ndncert/ndncert-ca.conf.j2
+++ b/templates/ndncert/ndncert-ca.conf.j2
@@ -9,7 +9,8 @@
   ],
   "name-assignment":
   {
-    "email": "{{ site }}"
+    "param":"/email",
+    "email": "{{ site }}",
   },
   "supported-challenges":
   [


### PR DESCRIPTION
On emails, the CAs will give an option for the `/<ca-prefix>/<raw email>` name. For example, the email `user@sub.domain.tld` for a CA with prefix `/ndn/ca-prefix` will be given the option to request the name `/ndn/ca-prefix/user@sub.domain.tld`.

As a side note, the `@` will convert into `%40` in the encoding, so it's a bit less human readable/typable.

Sites now have the name `/ndn/<DNS name>`