### PR TITLE
Bump nfd-status-http-server to 20260420

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -18,10 +18,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
-
-      - name: Install dependencies
-        run: python -m pip install PyYAML
+          python-version: '3.14'
+          pip-install: PyYAML
 
       - name: Lint
         run: python framework/lint.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       driver: local
 
   nfd-http-status-server:
-    image: ghcr.io/named-data/nfd-status-http-server:20250420
+    image: ghcr.io/named-data/nfd-status-http-server:20260420
     init: true
     volumes:
       - /run/nfd:/run/nfd:ro


### PR DESCRIPTION
Incorporates the fix for https://redmine.named-data.net/issues/5385, plus some minor simplifications to the lint workflow.

~_Draft until the updated container image is published_~